### PR TITLE
Add impls for `AsExpression<T>` and `AsExpression<Nullable<T>>`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,22 @@ fn pg_enum_impls(
             impl NotNull for #diesel_type {}
             impl SingleValue for #diesel_type {}
 
+            impl AsExpression<#diesel_type> for #enum_ {
+                type Expression = Bound<#diesel_type, #enum_>;
+
+                fn as_expression(self) -> Self::Expression {
+                    Bound::new(self)
+                }
+            }
+
+            impl AsExpression<Nullable<#diesel_type>> for #enum_ {
+                type Expression = Bound<Nullable<#diesel_type>, #enum_>;
+
+                fn as_expression(self) -> Self::Expression {
+                    Bound::new(self)
+                }
+            }
+
             impl<'a> AsExpression<#diesel_type> for &'a #enum_ {
                 type Expression = Bound<#diesel_type, &'a #enum_>;
 


### PR DESCRIPTION
So far, only `AsExpression<&T>` and `AsExpression<Nullable<&T>>` were implemented. (this lead to lifetime issues in my particular case, which was returning a boxed `Expression` for dynamic queries)