### PR TITLE
Change from deprecated types to updated types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ syn = "0.11.11"
 heck = "0.3.0"
 
 [dev-dependencies]
-diesel = {version = ">=1.1", features = ["postgres"] }
+diesel = {version = "1.1", features = ["postgres"] }
 
 [lib]
 name = "diesel_derive_enum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ syn = "0.11.11"
 heck = "0.3.0"
 
 [dev-dependencies]
-diesel = {version = "1", features = ["postgres"] }
+diesel = {version = ">=1.1", features = ["postgres"] }
 
 [lib]
 name = "diesel_derive_enum"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,9 +79,8 @@ fn pg_enum_impls(
             use diesel::pg::Pg;
             use diesel::row::Row;
             use diesel::sql_types::*;
-            use diesel::serialize::{ToSql, IsNull, Output};
-            use diesel::deserialize::FromSqlRow;
-            use std::error::Error;
+            use diesel::serialize::{self, ToSql, IsNull, Output};
+            use diesel::deserialize::{self, FromSqlRow};
             use std::io::Write;
 
             pub struct #diesel_type;
@@ -128,10 +127,7 @@ fn pg_enum_impls(
             }
 
             impl ToSql<#diesel_type, Pg> for #enum_ {
-                fn to_sql<W: Write>(
-                    &self,
-                    out: &mut Output<W, Pg>,
-                ) -> Result<IsNull, Box<Error + Send + Sync>> {
+                fn to_sql<W: Write>(&self, out: &mut Output<W, Pg>) -> serialize::Result {
                     match *self {
                         #(#variants => out.write_all(#variants_pg)?,)*
                     }
@@ -140,7 +136,7 @@ fn pg_enum_impls(
             }
 
             impl FromSqlRow<#diesel_type, Pg> for #enum_ {
-                fn build_from_row<T: Row<Pg>>(row: &mut T) -> Result<Self, Box<Error + Send + Sync>> {
+                fn build_from_row<T: Row<Pg>>(row: &mut T) -> deserialize::Result<Self> {
                     match row.take() {
                         #(Some(#variants_pg) => Ok(#variants),)*
                         Some(v) => Err(format!("Unrecognized enum variant: '{}'",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,9 @@ fn pg_enum_impls(
             use diesel::expression::bound::Bound;
             use diesel::pg::Pg;
             use diesel::row::Row;
-            use diesel::types::*;
+            use diesel::sql_types::*;
+            use diesel::serialize::{ToSql, IsNull, Output};
+            use diesel::deserialize::FromSqlRow;
             use std::error::Error;
             use std::io::Write;
 
@@ -128,7 +130,7 @@ fn pg_enum_impls(
             impl ToSql<#diesel_type, Pg> for #enum_ {
                 fn to_sql<W: Write>(
                     &self,
-                    out: &mut ToSqlOutput<W, Pg>,
+                    out: &mut Output<W, Pg>,
                 ) -> Result<IsNull, Box<Error + Send + Sync>> {
                     match *self {
                         #(#variants => out.write_all(#variants_pg)?,)*

--- a/tests/rename.rs
+++ b/tests/rename.rs
@@ -26,7 +26,7 @@ pub enum RenameMe {
 }
 
 table! {
-    use diesel::types::Integer;
+    use diesel::sql_types::Integer;
     use super::Some_Ugly_Renaming;
     test_rename {
         id -> Integer,

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -18,7 +18,7 @@ pub enum MyEnum {
 }
 
 table! {
-    use diesel::types::Integer;
+    use diesel::sql_types::Integer;
     use super::MyEnumMapping;
     test_simple {
         id -> Integer,
@@ -90,7 +90,7 @@ pub enum my_enum {
 }
 
 table! {
-    use diesel::types::Integer;
+    use diesel::sql_types::Integer;
     use super::my_enumMapping;
     test_snakey {
         id -> Integer,
@@ -108,7 +108,7 @@ struct test_snake {
 // test nullable compiles
 
 table! {
-    use diesel::types::{Integer, Nullable};
+    use diesel::sql_types::{Integer, Nullable};
     use super::MyEnumMapping;
     test_nullable {
         id -> Integer,


### PR DESCRIPTION
Currently using the deprecated types brings up warnings in crates trying to use this.