### PR TITLE
Sqlite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,7 @@ services:
   - postgresql
 env:
   TEST_DATABASE_URL=postgres://postgres@localhost:5432
+script:
+  - cargo build --verbose --all
+  - cargo test --features="sqlite"
+  - cargo test --features="postgres"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,10 @@ readme = "README.md"
 quote = "0.3.15"
 syn = "0.11.11"
 heck = "0.3.0"
+diesel = {version = "1.1", features = ["postgres", "sqlite"] }
 
 [dev-dependencies]
-diesel = {version = "1.1", features = ["postgres"] }
+diesel = {version = "1.1", features = ["postgres", "sqlite"] }
 
 [lib]
 name = "diesel_derive_enum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel-derive-enum"
-version = "0.3.0"
+version = "0.4.0"
 description = "Derive diesel boilerplate for using enums in Postgres"
 authors = ["Alex Whitney <adwhit@fastmail.com>"]
 repository = "http://github.com/adwhit/diesel-derive-enum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "diesel-derive-enum"
 version = "0.4.0"
-description = "Derive diesel boilerplate for using enums in Postgres"
+description = "Derive diesel boilerplate for using enums in databases"
 authors = ["Alex Whitney <adwhit@fastmail.com>"]
 repository = "http://github.com/adwhit/diesel-derive-enum"
 homepage = "http://github.com/adwhit/diesel-derive-enum"
-keywords = ["diesel", "postgres", "derive"]
+keywords = ["diesel", "postgres", "sqlite", "sql", "derive"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,13 @@ readme = "README.md"
 quote = "0.3.15"
 syn = "0.11.11"
 heck = "0.3.0"
-diesel = {version = "1.1", features = ["postgres", "sqlite"] }
 
 [dev-dependencies]
 diesel = {version = "1.1", features = ["postgres", "sqlite"] }
+
+[features]
+postgres = []
+sqlite = []
 
 [lib]
 name = "diesel_derive_enum"

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ diesel-derive-enum = { version = "0.4", features = ["postgres"] }
 
 // define your enum
 #[derive(DbEnum)]
-pub enum MyEnum {      // All enum variants must be fieldless
-    Foo,
+pub enum MyEnum {
+    Foo,  // All variants must be fieldless
     Bar,
     BazQuxx,
 }
@@ -82,14 +82,14 @@ assert_eq!(data, inserted);
 
 See [this test](tests/simple.rs) for a full working example.
 
-### Sqlite
+### sqlite
 
-Sqlite is untyped. [Yes, really.](https://dba.stackexchange.com/questions/106364/text-string-stored-in-sqlite-integer-column). You can store any kind of data in any column and it won't complain. How do we get some nice static checking then? Well... you can't, really, but you can emulate it by add a `CHECK` to your column definition like so:
+`sqlite` is untyped. [Yes, really.](https://dba.stackexchange.com/questions/106364/text-string-stored-in-sqlite-integer-column). You can store any kind of data in any column and it won't complain. How do we get some nice static checking then? Well... you can't, really, but you can emulate it by add a `CHECK` to your column definition like so:
 
 ```sql
 CREATE TABLE test_simple (
     id SERIAL PRIMARY KEY,
-    my_enum TEXT CHECK(my_enum IN ('foo', 'bar', 'baz_quxx')) NOT NULL
+    some_enum TEXT CHECK(my_enum IN ('foo', 'bar', 'baz_quxx')) NOT NULL
 );
 ```
 

--- a/tests/rename.rs
+++ b/tests/rename.rs
@@ -6,9 +6,7 @@ pub extern crate diesel;
 #[macro_use]
 extern crate diesel_derive_enum;
 
-use ::diesel::prelude::*;
-use ::diesel::insert_into;
-use diesel::connection::SimpleConnection;
+use diesel::prelude::*;
 
 pub fn connection() -> PgConnection {
     let database_url =
@@ -16,7 +14,7 @@ pub fn connection() -> PgConnection {
     PgConnection::establish(&database_url).expect(&format!("Failed to connect to {}", database_url))
 }
 
-#[derive(Debug, PartialEq, PgEnum)]
+#[derive(Debug, PartialEq, DbEnum)]
 #[PgType = "Just_Whatever"]
 #[DieselType = "Some_Ugly_Renaming"]
 pub enum RenameMe {
@@ -38,11 +36,14 @@ table! {
 #[table_name = "test_rename"]
 struct TestRename {
     id: i32,
-    renamed: RenameMe
+    renamed: RenameMe,
 }
 
 #[test]
+#[cfg(feature = "postgres")]
 fn rename_round_trip() {
+    use diesel::connection::SimpleConnection;
+    use diesel::insert_into;
     let data = vec![
         TestRename {
             id: 1,
@@ -50,7 +51,7 @@ fn rename_round_trip() {
         },
         TestRename {
             id: 2,
-            renamed: RenameMe::WithASpace
+            renamed: RenameMe::WithASpace,
         },
     ];
     let connection = connection();

--- a/tests/rename.rs
+++ b/tests/rename.rs
@@ -20,9 +20,9 @@ pub fn connection() -> PgConnection {
 #[PgType = "Just_Whatever"]
 #[DieselType = "Some_Ugly_Renaming"]
 pub enum RenameMe {
-    #[pg_rename = "mod"] Mod,
-    #[pg_rename = "type"] typo,
-    #[pg_rename = "with spaces"] WithASpace,
+    #[db_rename = "mod"] Mod,
+    #[db_rename = "type"] typo,
+    #[db_rename = "with spaces"] WithASpace,
 }
 
 table! {

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -45,33 +45,7 @@ pub fn sqlite_connection() -> SqliteConnection {
 }
 
 #[test]
-fn sqlite_enum_round_trip() {
-    let data = vec![
-        Simple {
-            id: 1,
-            my_enum: MyEnum::Foo,
-        },
-        Simple {
-            id: 2,
-            my_enum: MyEnum::BazQuxx,
-        },
-    ];
-    let connection = sqlite_connection();
-    connection
-        .execute(r#"
-        CREATE TABLE test_simple (
-            id SERIAL PRIMARY KEY,
-            my_enum my_enum NOT NULL
-        );
-    "#).unwrap();
-    let ct = insert_into(test_simple::table)
-        .values(&data)
-        .execute(&connection).unwrap();
-    assert_eq!(data.len(), ct);
-}
-
-#[test]
-fn enum_round_trip() {
+fn pg_enum_round_trip() {
     let data = vec![
         Simple {
             id: 1,
@@ -109,6 +83,35 @@ fn enum_round_trip() {
         )
         .unwrap();
 }
+
+#[test]
+fn sqlite_enum_round_trip() {
+    let data = vec![
+        Simple {
+            id: 1,
+            my_enum: MyEnum::Foo,
+        },
+        Simple {
+            id: 2,
+            my_enum: MyEnum::BazQuxx,
+        },
+    ];
+    let connection = sqlite_connection();
+    connection
+        .execute(r#"
+        CREATE TABLE test_simple (
+            id SERIAL PRIMARY KEY,
+            my_enum my_enum NOT NULL
+        );
+    "#).unwrap();
+    let ct = insert_into(test_simple::table)
+        .values(&data)
+        .execute(&connection).unwrap();
+    assert_eq!(data.len(), ct);
+    let items = test_simple::table.load::<Simple>(&connection).unwrap();
+    assert_eq!(data, items);
+}
+
 
 // test snakey naming - should compile and not clobber above definitions
 // (but we won't actually bother round-tripping)


### PR DESCRIPTION
The PR adds sqlite support.

Since the tag `PgEnum` no longer makes sense, the derive annotation has been changed to `DbEnum`. One must now specify which database one is using through  crate features e.g. `features = ["postgres"]`. This is similar to how `diesel` does things. There are no default features, however.

Closes #6

cc @eijebong