### PR TITLE
Implement Clone trait for #diesel_mapping.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,11 @@ fn generate_common_impl(
             type QueryId = #diesel_mapping;
             const HAS_STATIC_QUERY_ID: bool = true;
         }
+        impl Clone for #diesel_mapping {
+            fn clone(&self) -> Self {
+                #diesel_mapping {}
+            }
+        }
         impl NotNull for #diesel_mapping {}
         impl SingleValue for #diesel_mapping {}
 


### PR DESCRIPTION
Diesel returns an error because Clone is not implemented for the <Enum>Mapping type, since diesel::expression::bound::Bound implements Clone trait.