### PR TITLE
Add stylized value conversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,10 +124,23 @@ Specifically, we assume `MyEnum` corresponds to `my_enum` in Postgres and `MyEnu
 These defaults can be overridden with the attributes `#[PgType = "..."]` and `#[DieselType = "..."]`.
 (The `PgType` annotation has no effect on `MySQL` or `sqlite`).
 
-Similarly, we assume that the possible ENUM variants are simply the Rust enum variants
-translated to `snake_case`. These can be renamed with the inline annotation `#[db_rename = "..."]`.
+Similarly, by default we assume that the possible ENUM variants are simply the Rust enum variants
+translated to `snake_case`.  These can be renamed with the inline annotation `#[db_rename = "..."]`.
 
 See [this test](tests/src/rename.rs) for an example of renaming.
+
+You can override the `snake_case` assumption for the entire enum using the `#[DbValueStyle = "..."]` attribute.  Individual variants can still be renamed using `#[db_rename = "..."]`.
+
+| DbValueStyle   | Variant | Value   |
+|:-------------------:|:---------:|:---|
+| camelCase | BazQuxx | "bazQuxx" |
+| kebab-case | BazQuxx | "baz-quxx" |
+| PascalCase | BazQuxx | "BazQuxx" |
+| SCREAMING_SNAKE | BazQuxx | "BAZ_QUXX" |
+| snake_case | BazQuxx | "baz_quxx" |
+| verbatim | Baz__quxx | "Baz__quxx" |
+
+See [this test](tests/src/value_style.rs) for an example of changing the output style.
 
 #### `print-schema` and `infer-schema!`
 

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -11,3 +11,4 @@ mod nullable;
 mod pg_array;
 mod rename;
 mod simple;
+mod value_style;

--- a/tests/src/value_style.rs
+++ b/tests/src/value_style.rs
@@ -1,0 +1,141 @@
+use diesel::prelude::*;
+
+#[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
+use crate::common::get_connection;
+
+#[derive(Debug, PartialEq, diesel_derive_enum::DbEnum)]
+#[PgType = "Stylized_External_Type"]
+#[DieselType = "Stylized_Internal_Type"]
+#[DbValueStyle = "PascalCase"]
+pub enum StylizedEnum {
+    FirstVariant,
+    secondThing,
+    third_item,
+    FOURTH_VALUE,
+    #[db_rename = "crazy fifth"]
+    cRaZy_FiFtH,
+}
+
+table! {
+    use diesel::sql_types::Integer;
+    use super::Stylized_Internal_Type;
+    test_value_style {
+        id -> Integer,
+        value -> Stylized_Internal_Type,
+    }
+}
+
+#[derive(Insertable, Queryable, Identifiable, Debug, PartialEq)]
+#[table_name = "test_value_style"]
+struct TestStylized {
+    id: i32,
+    value: StylizedEnum,
+}
+
+fn sample_data() -> Vec<TestStylized> {
+    vec![
+        TestStylized {
+            id: 1,
+            value: StylizedEnum::FirstVariant,
+        },
+        TestStylized {
+            id: 2,
+            value: StylizedEnum::secondThing,
+        },
+        TestStylized {
+            id: 3,
+            value: StylizedEnum::third_item,
+        },
+        TestStylized {
+            id: 4,
+            value: StylizedEnum::FOURTH_VALUE,
+        },
+        TestStylized {
+            id: 5,
+            value: StylizedEnum::cRaZy_FiFtH,
+        },
+    ]
+}
+
+#[test]
+#[cfg(feature = "postgres")]
+fn stylized_round_trip() {
+    use diesel::connection::SimpleConnection;
+    use diesel::insert_into;
+    let data = sample_data();
+    let connection = get_connection();
+    connection
+        .batch_execute(
+            r#"
+        CREATE TYPE Stylized_External_Type AS ENUM (
+            'FirstVariant', 'SecondThing', 'ThirdItem', 'FourthValue', 'crazy fifth');
+        CREATE TABLE test_value_style (
+            id SERIAL PRIMARY KEY,
+            value Stylized_External_Type NOT NULL
+        );
+    "#,
+        )
+        .unwrap();
+    let inserted = insert_into(test_value_style::table)
+        .values(&data)
+        .get_results(&connection)
+        .unwrap();
+    assert_eq!(data, inserted);
+}
+
+#[test]
+#[cfg(feature = "mysql")]
+fn rename_round_trip() {
+    use diesel::connection::SimpleConnection;
+    use diesel::insert_into;
+    let data = sample_data();
+    let connection = get_connection();
+    connection
+        .batch_execute(
+            r#"
+        CREATE TEMPORARY TABLE IF NOT EXISTS test_value_style (
+            id SERIAL PRIMARY KEY,
+            value enum('FirstVariant', 'SecondThing', 'ThirdItem', 'FourthValue', 'crazy fifth')
+                NOT NULL
+        );
+    "#,
+        )
+        .unwrap();
+    insert_into(test_value_style::table)
+        .values(&data)
+        .execute(&connection)
+        .unwrap();
+    let inserted = test_value_style::table
+        .load::<TestStylized>(&connection)
+        .unwrap();
+    assert_eq!(data, inserted);
+}
+
+#[test]
+#[cfg(feature = "sqlite")]
+fn rename_round_trip() {
+    use diesel::connection::SimpleConnection;
+    use diesel::insert_into;
+    let data = sample_data();
+    let connection = get_connection();
+    connection
+        .batch_execute(
+            r#"
+        CREATE TABLE test_value_style (
+            id SERIAL PRIMARY KEY,
+            value TEXT CHECK(value IN (
+                'FirstVariant', 'SecondThing', 'ThirdItem', 'FourthValue', 'crazy fifth'
+            )) NOT NULL
+        );
+    "#,
+        )
+        .unwrap();
+    insert_into(test_value_style::table)
+        .values(&data)
+        .execute(&connection)
+        .unwrap();
+    let inserted = test_value_style::table
+        .load::<TestStylized>(&connection)
+        .unwrap();
+    assert_eq!(data, inserted);
+}


### PR DESCRIPTION
Particularly in sqlite, it's nice to be able to have a bit of control over the style of the text representations for enums in the database.  While we can already use "#[db_rename = "..."], it is tedious to need to do that for every variant within the enum when you want them all to be a consistent style (other than the default "snake_case").  This change introduces the ability to use other styles provided by the heck crate that is already in use.

I'm open to any suggestions you may have to improve this, renaming things, etc.  Thanks for taking a look!