### PR TITLE
Updates for the new Diesel internal type system

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,7 +186,6 @@ fn generate_common_impl(
             type QueryId = #diesel_mapping;
             const HAS_STATIC_QUERY_ID: bool = true;
         }
-        impl NotNull for #diesel_mapping {}
         impl SingleValue for #diesel_mapping {}
 
         impl AsExpression<#diesel_mapping> for #enum_ty {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,12 +276,11 @@ fn generate_postgres_impl(
             }
 
             impl FromSql<#diesel_mapping, Pg> for #enum_ty {
-                fn from_sql(raw: Option<PgValue>) -> deserialize::Result<Self> {
-                    match raw.as_ref().map(|r| r.as_bytes()) {
-                        #(Some(#variants_db) => Ok(#variants_rs),)*
-                        Some(v) => Err(format!("Unrecognized enum variant: '{}'",
+                fn from_sql(raw: PgValue) -> deserialize::Result<Self> {
+                    match raw.as_bytes() {
+                        #((#variants_db) => Ok(#variants_rs),)*
+                        v => Err(format!("Unrecognized enum variant: '{}'",
                                                String::from_utf8_lossy(v)).into()),
-                        None => Err("Unexpected null for non-null column".into()),
                     }
                 }
             }
@@ -319,12 +318,11 @@ fn generate_mysql_impl(
             }
 
             impl FromSql<#diesel_mapping, Mysql> for #enum_ty {
-                fn from_sql(raw: Option<MysqlValue>) -> deserialize::Result<Self> {
-                    match raw.as_ref().map(|r| r.as_bytes()) {
-                        #(Some(#variants_db) => Ok(#variants_rs),)*
-                        Some(v) => Err(format!("Unrecognized enum variant: '{}'",
+                fn from_sql(raw: MysqlValue) -> deserialize::Result<Self> {
+                    match raw.as_bytes() {
+                        #((#variants_db) => Ok(#variants_rs),)*
+                        v => Err(format!("Unrecognized enum variant: '{}'",
                                                String::from_utf8_lossy(v)).into()),
-                        None => Err("Unexpected null for non-null column".into()),
                     }
                 }
             }
@@ -359,11 +357,10 @@ fn generate_sqlite_impl(
             }
 
             impl FromSql<#diesel_mapping, Sqlite> for #enum_ty {
-                fn from_sql(bytes: Option<backend::RawValue<Sqlite>>) -> deserialize::Result<Self> {
+                fn from_sql(bytes: backend::RawValue<Sqlite>) -> deserialize::Result<Self> {
                     match bytes.map(|v| v.read_blob()) {
-                        #(Some(#variants_db) => Ok(#variants_rs),)*
-                        Some(blob) => Err(format!("Unexpected variant: {}", String::from_utf8_lossy(blob)).into()),
-                        None => Err("Unexpected null for non-null column".into()),
+                        #((#variants_db) => Ok(#variants_rs),)*
+                        blob => Err(format!("Unexpected variant: {}", String::from_utf8_lossy(blob)).into()),
                     }
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,10 +310,7 @@ fn generate_mysql_impl(
 
             impl HasSqlType<#diesel_mapping> for Mysql {
                 fn metadata(_lookup: &Self::MetadataLookup) -> Self::TypeMetadata {
-                    diesel::mysql::MysqlTypeMetadata {
-                        data_type: diesel::mysql::MysqlType::String,
-                        is_unsigned: false
-                    }
+                    diesel::mysql::MysqlType::Enum
                 }
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,6 +181,7 @@ fn generate_common_impl(
         use diesel::query_builder::QueryId;
         use std::io::Write;
 
+        #[derive(SqlType)]
         pub struct #diesel_mapping;
         impl QueryId for #diesel_mapping {
             type QueryId = #diesel_mapping;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,7 +177,7 @@ fn generate_common_impl(
         use diesel::row::Row;
         use diesel::sql_types::*;
         use diesel::serialize::{self, ToSql, IsNull, Output};
-        use diesel::deserialize::{self, FromSql, FromSqlRow};
+        use diesel::deserialize::{self, FromSql};
         use diesel::query_builder::QueryId;
         use std::io::Write;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,7 +187,6 @@ fn generate_common_impl(
             type QueryId = #diesel_mapping;
             const HAS_STATIC_QUERY_ID: bool = true;
         }
-        impl SingleValue for #diesel_mapping {}
 
         impl AsExpression<#diesel_mapping> for #enum_ty {
             type Expression = Bound<#diesel_mapping, Self>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,12 +275,6 @@ fn generate_postgres_impl(
                 }
             }
 
-            impl FromSqlRow<#diesel_mapping, Pg> for #enum_ty {
-                fn build_from_row<T: Row<Pg>>(row: &mut T) -> deserialize::Result<Self> {
-                    FromSql::<#diesel_mapping, Pg>::from_sql(row.take())
-                }
-            }
-
             impl FromSql<#diesel_mapping, Pg> for #enum_ty {
                 fn from_sql(raw: Option<PgValue>) -> deserialize::Result<Self> {
                     match raw.as_ref().map(|r| r.as_bytes()) {
@@ -324,12 +318,6 @@ fn generate_mysql_impl(
                 }
             }
 
-            impl FromSqlRow<#diesel_mapping, Mysql> for #enum_ty {
-                fn build_from_row<T: Row<Mysql>>(row: &mut T) -> deserialize::Result<Self> {
-                    FromSql::<#diesel_mapping, Mysql>::from_sql(row.take())
-                }
-            }
-
             impl FromSql<#diesel_mapping, Mysql> for #enum_ty {
                 fn from_sql(raw: Option<MysqlValue>) -> deserialize::Result<Self> {
                     match raw.as_ref().map(|r| r.as_bytes()) {
@@ -367,12 +355,6 @@ fn generate_sqlite_impl(
             impl HasSqlType<#diesel_mapping> for Sqlite {
                 fn metadata(_lookup: &Self::MetadataLookup) -> Self::TypeMetadata {
                     diesel::sqlite::SqliteType::Text
-                }
-            }
-
-            impl FromSqlRow<#diesel_mapping, Sqlite> for #enum_ty {
-                fn build_from_row<T: Row<Sqlite>>(row: &mut T) -> deserialize::Result<Self> {
-                    FromSql::<#diesel_mapping, Sqlite>::from_sql(row.take())
                 }
             }
 

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -15,7 +15,7 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 [[package]]
 name = "diesel"
 version = "2.0.0"
-source = "git+https://github.com/diesel-rs/diesel#6cd920184782745a46ee77d29ce20215228b9ed6"
+source = "git+https://github.com/diesel-rs/diesel#91493fe47175076f330ce5fc518f0196c0476f56"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -41,7 +41,7 @@ dependencies = [
 [[package]]
 name = "diesel_derives"
 version = "2.0.0"
-source = "git+https://github.com/diesel-rs/diesel#6cd920184782745a46ee77d29ce20215228b9ed6"
+source = "git+https://github.com/diesel-rs/diesel#91493fe47175076f330ce5fc518f0196c0476f56"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -4,206 +4,209 @@
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "diesel"
 version = "2.0.0"
-source = "git+https://github.com/diesel-rs/diesel#fe87242595ef70abe9a1f4a745f40d3c7110b1bb"
+source = "git+https://github.com/diesel-rs/diesel#6cd920184782745a46ee77d29ce20215228b9ed6"
 dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "diesel_derives 2.0.0 (git+https://github.com/diesel-rs/diesel)",
- "libsqlite3-sys 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "mysqlclient-sys 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pq-sys 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags",
+ "byteorder",
+ "diesel_derives",
+ "itoa",
+ "libsqlite3-sys",
+ "mysqlclient-sys",
+ "percent-encoding",
+ "pq-sys",
+ "url",
 ]
 
 [[package]]
 name = "diesel-derive-enum"
 version = "2.0.0-pre"
 dependencies = [
- "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "diesel_derives"
 version = "2.0.0"
-source = "git+https://github.com/diesel-rs/diesel#fe87242595ef70abe9a1f4a745f40d3c7110b1bb"
+source = "git+https://github.com/diesel-rs/diesel#6cd920184782745a46ee77d29ce20215228b9ed6"
 dependencies = [
- "proc-macro2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "heck"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 dependencies = [
- "unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-segmentation",
 ]
 
 [[package]]
 name = "idna"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 dependencies = [
- "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-normalization 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "libsqlite3-sys"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3711dfd91a1081d2458ad2d06ea30a8755256e74038be2ad927d94e1c955ca8"
 dependencies = [
- "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "mysqlclient-sys"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e9637d93448044078aaafea7419aed69d301b4a12bcc4aa0ae856eb169bef85"
 dependencies = [
- "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pkg-config"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 
 [[package]]
 name = "pq-sys"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ac25eee5a0582f45a67e837e350d784e7003bd29a5f460796772061ca49ffda"
 dependencies = [
- "vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg",
 ]
 
 [[package]]
 name = "proc-macro2"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8872cf6f48eee44265156c111456a700ab3483686b3f96df4cf5481c89157319"
 dependencies = [
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c1f4b0efa5fc5e8ceb705136bfee52cfdb6a4e3509f770b478cd6ed434232a7"
 dependencies = [
- "proc-macro2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
 ]
 
 [[package]]
 name = "smallvec"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
 
 [[package]]
 name = "syn"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e5aa70697bb26ee62214ae3288465ecec0000f05182f039b477001f08f5ae7"
 dependencies = [
- "proc-macro2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
 name = "tests"
 version = "0.1.0"
 dependencies = [
- "diesel 2.0.0 (git+https://github.com/diesel-rs/diesel)",
- "diesel-derive-enum 2.0.0-pre",
+ "diesel",
+ "diesel-derive-enum",
 ]
 
 [[package]]
 name = "unicode-bidi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 dependencies = [
- "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches",
 ]
 
 [[package]]
 name = "unicode-normalization"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
 dependencies = [
- "smallvec 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 
 [[package]]
 name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
 name = "url"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
 dependencies = [
- "idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "idna",
+ "matches",
+ "percent-encoding",
 ]
 
 [[package]]
 name = "vcpkg"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[metadata]
-"checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-"checksum byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
-"checksum diesel 2.0.0 (git+https://github.com/diesel-rs/diesel)" = "<none>"
-"checksum diesel_derives 2.0.0 (git+https://github.com/diesel-rs/diesel)" = "<none>"
-"checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
-"checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
-"checksum libsqlite3-sys 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d3711dfd91a1081d2458ad2d06ea30a8755256e74038be2ad927d94e1c955ca8"
-"checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
-"checksum mysqlclient-sys 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7e9637d93448044078aaafea7419aed69d301b4a12bcc4aa0ae856eb169bef85"
-"checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
-"checksum pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
-"checksum pq-sys 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "6ac25eee5a0582f45a67e837e350d784e7003bd29a5f460796772061ca49ffda"
-"checksum proc-macro2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "8872cf6f48eee44265156c111456a700ab3483686b3f96df4cf5481c89157319"
-"checksum quote 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4c1f4b0efa5fc5e8ceb705136bfee52cfdb6a4e3509f770b478cd6ed434232a7"
-"checksum smallvec 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
-"checksum syn 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "e8e5aa70697bb26ee62214ae3288465ecec0000f05182f039b477001f08f5ae7"
-"checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
-"checksum unicode-normalization 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
-"checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
-"checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
-"checksum url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
-"checksum vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
+checksum = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -9,9 +9,3 @@ mod pg_array;
 mod rename;
 mod simple;
 mod value_style;
-
-#[derive(Debug, PartialEq, diesel_derive_enum::DbEnum)]
-pub enum my_enum {
-    foo,
-    bazQuxx,
-}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -9,3 +9,9 @@ mod pg_array;
 mod rename;
 mod simple;
 mod value_style;
+
+#[derive(Debug, PartialEq, diesel_derive_enum::DbEnum)]
+pub enum my_enum {
+    foo,
+    bazQuxx,
+}


### PR DESCRIPTION
See https://github.com/diesel-rs/diesel/commit/ee470bb07c1366fb643aba588cf989552e05b02c

The `NotNull` trait was removed, and instead custom types are expected to implement `SqlType`, which is derivable.

I've removed the implementations of the `SingleValue` and `FromSqlRow` traits because they're now automatically implemented for types that derive `SqlType`.

I've also updated the `from_sql` templates because the function no longer takes an `Option` but takes a `PgValue` or, for SQLite, a `backend::RawValue<Sqlite>` directly (not 100% sure about this last one).