### PR TITLE
Compatibility with diesel master after 9301591

### DIFF
--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -15,7 +15,7 @@ checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 [[package]]
 name = "diesel"
 version = "2.0.0"
-source = "git+https://github.com/diesel-rs/diesel#3ab5d2d7d92a0ff7fae357e66028ecefc565478e"
+source = "git+https://github.com/diesel-rs/diesel#f307a4b980e3fbe22e4438cd2d73a8a47f88b563"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -41,7 +41,7 @@ dependencies = [
 [[package]]
 name = "diesel_derives"
 version = "2.0.0"
-source = "git+https://github.com/diesel-rs/diesel#3ab5d2d7d92a0ff7fae357e66028ecefc565478e"
+source = "git+https://github.com/diesel-rs/diesel#f307a4b980e3fbe22e4438cd2d73a8a47f88b563"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -15,7 +15,7 @@ checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 [[package]]
 name = "diesel"
 version = "2.0.0"
-source = "git+https://github.com/diesel-rs/diesel#96352904849d6430a2c051c00af4bcba0e8a0e8b"
+source = "git+https://github.com/diesel-rs/diesel#3ab5d2d7d92a0ff7fae357e66028ecefc565478e"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -41,7 +41,7 @@ dependencies = [
 [[package]]
 name = "diesel_derives"
 version = "2.0.0"
-source = "git+https://github.com/diesel-rs/diesel#96352904849d6430a2c051c00af4bcba0e8a0e8b"
+source = "git+https://github.com/diesel-rs/diesel#3ab5d2d7d92a0ff7fae357e66028ecefc565478e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/tests/src/rename.rs
+++ b/tests/src/rename.rs
@@ -50,10 +50,10 @@ fn rename_round_trip() {
     connection
         .batch_execute(
             r#"
-        CREATE TYPE Some_External_Type AS ENUM ('mod', 'type', 'with spaces');
+        CREATE TYPE "Some_External_Type" AS ENUM ('mod', 'type', 'with spaces');
         CREATE TABLE test_rename (
             id SERIAL PRIMARY KEY,
-            renamed Some_External_Type NOT NULL
+            renamed "Some_External_Type" NOT NULL
         );
     "#,
         )

--- a/tests/src/value_style.rs
+++ b/tests/src/value_style.rs
@@ -67,11 +67,11 @@ fn stylized_round_trip() {
     connection
         .batch_execute(
             r#"
-        CREATE TYPE Stylized_External_Type AS ENUM (
+        CREATE TYPE "Stylized_External_Type" AS ENUM (
             'FirstVariant', 'SecondThing', 'ThirdItem', 'FourthValue', 'crazy fifth');
         CREATE TABLE test_value_style (
             id SERIAL PRIMARY KEY,
-            value Stylized_External_Type NOT NULL
+            value "Stylized_External_Type" NOT NULL
         );
     "#,
         )
@@ -85,7 +85,7 @@ fn stylized_round_trip() {
 
 #[test]
 #[cfg(feature = "mysql")]
-fn rename_round_trip() {
+fn stylized_round_trip() {
     use diesel::connection::SimpleConnection;
     use diesel::insert_into;
     let data = sample_data();
@@ -113,7 +113,7 @@ fn rename_round_trip() {
 
 #[test]
 #[cfg(feature = "sqlite")]
-fn rename_round_trip() {
+fn stylized_round_trip() {
     use diesel::connection::SimpleConnection;
     use diesel::insert_into;
     let data = sample_data();


### PR DESCRIPTION
Using the feature of the `SqlType` derive that enables implementing
`HasSqlType` for all common backends, we reduce the amount of code
and make it more robust to changes such as:
https://github.com/diesel-rs/diesel/pull/2628