### PR TITLE
Add attribute to specify postgres schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ translated to `snake_case`.  These can be renamed with the inline annotation `#[
 
 See [this test](tests/src/rename.rs) for an example of renaming.
 
+See [this test](tests/src/schema.rs) for an example of specifying a schema.
+
 You can override the `snake_case` assumption for the entire enum using the `#[DbValueStyle = "..."]` attribute.  Individual variants can still be renamed using `#[db_rename = "..."]`.
 
 | DbValueStyle   | Variant | Value   |

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -8,5 +8,6 @@ mod complex_join;
 mod nullable;
 mod pg_array;
 mod rename;
+mod schema;
 mod simple;
 mod value_style;

--- a/tests/src/schema.rs
+++ b/tests/src/schema.rs
@@ -1,0 +1,62 @@
+use diesel::prelude::*;
+
+#[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
+use crate::common::get_connection;
+
+#[derive(Debug, PartialEq, diesel_derive_enum::DbEnum)]
+#[PgSchema = "schema"]
+pub enum SomeEnum {
+    One,
+    Two,
+}
+
+table! {
+    use diesel::sql_types::Integer;
+    use super::SomeEnumMapping;
+    test_schema {
+        id -> Integer,
+        enum_ -> SomeEnumMapping,
+    }
+}
+
+#[derive(Insertable, Queryable, Identifiable, Debug, PartialEq)]
+#[table_name = "test_schema"]
+struct TestSchema {
+    id: i32,
+    enum_: SomeEnum,
+}
+
+#[test]
+#[cfg(feature = "postgres")]
+fn schema_round_trip() {
+    use diesel::connection::SimpleConnection;
+    use diesel::insert_into;
+    let data = vec![
+        TestSchema {
+            id: 1,
+            enum_: SomeEnum::One,
+        },
+        TestSchema {
+            id: 2,
+            enum_: SomeEnum::Two,
+        },
+    ];
+    let connection = get_connection();
+    connection
+        .batch_execute(
+            r#"
+        CREATE SCHEMA "schema";
+        CREATE TYPE "schema"."some_enum" AS ENUM ('one', 'two');
+        CREATE TABLE test_schema (
+            id SERIAL PRIMARY KEY,
+            enum_ "schema"."some_enum" NOT NULL
+        );
+    "#,
+        )
+        .unwrap();
+    let inserted = insert_into(test_schema::table)
+        .values(&data)
+        .get_results(&connection)
+        .unwrap();
+    assert_eq!(data, inserted);
+}


### PR DESCRIPTION
Adds a new attribute `PgSchema` mapping to the `type_schema` attribute on the `diesel::SqlType` macro introduced in https://github.com/diesel-rs/diesel/pull/2628 . This allows an enum to be specified in a particular schema.

Also added documentation on the `DbEnum` macro.