### PR TITLE
Support `QueryId` auto derive by CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ Suppose your project has the following `diesel.toml`:
 ``` toml
 [print_schema]
 file = "src/schema.rs"
+custom_type_derives = ["diesel::query_builder::QueryId"]
 ```
+(NB: the `custom_type_derives` config here matters and you will otherwise get `QueryId`-related errors.
+It becomes the default for new projects in [recent Diesel CLI versions](https://github.com/diesel-rs/diesel/pull/3308),
+but if your project was created before you may want to check on this).
 
 And the following SQL:
 ```sql

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Then diesel-cli will generate something like the following:
 // src/schema.rs
 
 pub mod sql_types {
-    #[derive(diesel::sql_types::SqlType)]
+    #[derive(diesel::sql_types::SqlType, diesel::query_builder::QueryId)]
     #[diesel(postgres_type(name = "my_enum"))]
     pub struct MyEnum;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,7 +204,7 @@ fn generate_derive_enum_impls(
             deserialize::{self, FromSql},
             expression::AsExpression,
             internal::derives::as_expression::Bound,
-            query_builder::{bind_collector::RawBytesBindCollector, QueryId},
+            query_builder::bind_collector::RawBytesBindCollector,
             row::Row,
             serialize::{self, IsNull, Output, ToSql},
             sql_types::*,
@@ -269,7 +269,7 @@ fn generate_new_diesel_mapping(new_diesel_mapping: &Ident) -> proc_macro2::Token
     // Note - we only generate a new mapping for mysql and sqlite, postgres
     // should already have one
     quote! {
-        #[derive(SqlType, Clone)]
+        #[derive(SqlType, Clone, diesel::query_builder::QueryId)]
         #[diesel(mysql_type(name = "Enum"))]
         #[diesel(sqlite_type(name = "Text"))]
         pub struct #new_diesel_mapping;
@@ -281,11 +281,6 @@ fn generate_common_impls(
     enum_ty: &Ident,
 ) -> proc_macro2::TokenStream {
     quote! {
-        impl QueryId for #diesel_mapping {
-            type QueryId = #diesel_mapping;
-            const HAS_STATIC_QUERY_ID: bool = true;
-        }
-
         impl AsExpression<#diesel_mapping> for #enum_ty {
             type Expression = Bound<#diesel_mapping, Self>;
 

--- a/tests/src/common.rs
+++ b/tests/src/common.rs
@@ -11,7 +11,7 @@ pub enum MyEnum {
 }
 
 #[cfg(feature = "postgres")]
-#[derive(diesel::sql_types::SqlType)]
+#[derive(diesel::sql_types::SqlType, diesel::query_builder::QueryId)]
 #[diesel(postgres_type(name = "my_enum"))]
 pub struct MyEnumPgMapping;
 

--- a/tests/src/complex_join.rs
+++ b/tests/src/complex_join.rs
@@ -8,7 +8,7 @@ table! {
     }
 }
 
-#[derive(diesel::sql_types::SqlType)]
+#[derive(diesel::sql_types::SqlType, diesel::query_builder::QueryId)]
 #[diesel(postgres_type(name = "server_status"))]
 pub struct Server_status_pg;
 

--- a/tests/src/rename.rs
+++ b/tests/src/rename.rs
@@ -3,7 +3,7 @@ use diesel::prelude::*;
 #[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
 use crate::common::get_connection;
 
-#[derive(diesel::sql_types::SqlType)]
+#[derive(diesel::sql_types::SqlType, diesel::query_builder::QueryId)]
 #[diesel(postgres_type(name = "Some_External_Type"))]
 pub struct Some_Internal_Type_Pg;
 

--- a/tests/src/simple.rs
+++ b/tests/src/simple.rs
@@ -88,7 +88,7 @@ pub enum my_enum {
     bazQuxx,
 }
 
-#[derive(diesel::sql_types::SqlType)]
+#[derive(diesel::sql_types::SqlType, diesel::query_builder::QueryId)]
 #[diesel(postgres_type(name = "my_enum"))]
 pub struct MyEnumPgMapping;
 #[cfg(feature = "postgres")]

--- a/tests/src/value_style.rs
+++ b/tests/src/value_style.rs
@@ -19,7 +19,7 @@ pub enum StylizedEnum {
     cRaZy_FiFtH,
 }
 
-#[derive(diesel::sql_types::SqlType)]
+#[derive(diesel::sql_types::SqlType, diesel::query_builder::QueryId)]
 #[diesel(postgres_type(name = "Stylized_External_Type"))]
 pub struct Stylized_Internal_Type_Pg;
 #[cfg(feature = "postgres")]


### PR DESCRIPTION
`#[derive(QueryId)]` will be provided as a default config parameter in
the diesel.toml config, so we should not manage it on our end anymore.

This is a breaking change, so we probably want to:
1. wait until what's described in the comment at
   https://github.com/diesel-rs/diesel/pull/3297#issuecomment-1232809465
   is applied on diesel master
2. merge this
3. wait until it's released in the 2.0 diesel CLI
4. release this as diesel-derive-enum 2.0

so that CIs won't ever auto-break during this process