### PR TITLE
Reinstitue QueryId impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel-derive-enum"
-version = "2.0.0"
+version = "2.0.1"
 description = "Derive diesel boilerplate for using enums in databases"
 authors = ["Alex Whitney <adwhit@fastmail.com>"]
 repository = "http://github.com/adwhit/diesel-derive-enum"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Unfortunately, it won't work out of the box, because any type which
 we wish to use with Diesel must implement various traits.
 Tedious to do by hand, easy to do with a `derive` macro - enter `diesel-derive-enum`.
 
-The latest release, `2.0.0`, is tested against `diesel 2.0.2` and `rustc 1.57`.
+The latest release, `2.0.1`, is tested against `diesel 2.0.2` and `rustc 1.57`.
 For earlier versions of `diesel`, check out the 1.X releases of this crate.
 
 ## Setup with Diesel CLI
@@ -42,7 +42,7 @@ or if not using Diesel CLI, see the next section.
 Cargo.toml:
 ```toml
 [dependencies]
-diesel-derive-enum = { version = "2.0.0", features = ["postgres"] }
+diesel-derive-enum = { version = "2.0.1", features = ["postgres"] }
 ```
 
 Suppose our project has the following `diesel.toml`:
@@ -113,7 +113,7 @@ your schema, the setup is a little different.
 Cargo.toml:
 ```toml
 [dependencies]
-diesel-derive-enum = { version = "2.0.0", features = ["postgres"] }
+diesel-derive-enum = { version = "2.0.1", features = ["postgres"] }
 ```
 
 SQL:
@@ -151,7 +151,7 @@ table! {
 Cargo.toml:
 ```toml
 [dependencies]
-diesel-derive-enum = { version = "2.0.0", features = ["mysql"] }
+diesel-derive-enum = { version = "2.0.1", features = ["mysql"] }
 ```
 
 SQL:
@@ -188,7 +188,7 @@ table! {
 Cargo.toml:
 ```toml
 [dependencies]
-diesel-derive-enum = { version = "2.0.0", features = ["sqlite"] }
+diesel-derive-enum = { version = "2.0.1", features = ["sqlite"] }
 ```
 
 SQL:

--- a/tests_with_diesel_cli/run.sh
+++ b/tests_with_diesel_cli/run.sh
@@ -3,20 +3,20 @@ set -xe
 
 export DATABASE_URL=postgres://postgres:postgres@localhost:5432
 
-rm -rf src/schema.rs
-rm -rf src/custom_schema.rs
+rm -f src/schema.rs
+rm -f src/custom_schema.rs
 
 # create a 'default' schema
 docker-compose down
 docker-compose up -d
-sleep 1
+sleep 2
 
 diesel migration run
 cargo test
-rm -rf src/schema.rs
 diesel migration revert
+rm src/schema.rs
 
 # create a custom schema
 diesel migration run --config-file custom.diesel.toml
 cargo test --features custom
-rm -rf src/custom_schema.rs
+rm src/custom_schema.rs

--- a/tests_with_diesel_cli/src/lib.rs
+++ b/tests_with_diesel_cli/src/lib.rs
@@ -13,9 +13,8 @@ pub use diesel::pg::PgConnection as Conn;
 pub use diesel::Connection;
 
 pub fn get_connection() -> Conn {
-    let database_url =
-        ::std::env::var("DATABASE_URL").expect("Env var DATABASE_URL not set");
-    let conn = Conn::establish(&database_url)
-        .expect(&format!("Failed to connect to {}", database_url));
+    let database_url = ::std::env::var("DATABASE_URL").expect("Env var DATABASE_URL not set");
+    let conn =
+        Conn::establish(&database_url).expect(&format!("Failed to connect to {}", database_url));
     conn
 }

--- a/tests_with_diesel_cli/src/with_default_schema.rs
+++ b/tests_with_diesel_cli/src/with_default_schema.rs
@@ -38,5 +38,12 @@ mod tests {
         };
         let that = insert(&mut conn, &this).unwrap();
         assert_eq!(this, that);
+
+        // make a query that requires QueryId trait to exist
+        let _: Vec<Simple> = simple::table
+            .filter(simple::some_value.eq(MyEnum::Foo))
+            .limit(1)
+            .load(&mut conn)
+            .unwrap();
     }
 }


### PR DESCRIPTION
It turns out removing the `QueryId` for the `diesel-cli` path was an error, that happened to not be covered by the test. It happens...

Bumping version to `2.0.1`

Closes #10 