### PR TITLE
v2.1

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.57
+          - 1.65
 
     services:
       postgres:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -79,10 +79,11 @@ jobs:
           cd tests_with_diesel_cli
 
           # with default schema
+          diesel setup
           diesel migration run
           cargo test
-          rm -rf src/schema.rs
           diesel migration revert
+          rm src/schema.rs diesel.toml
 
           # create a custom schema
           diesel migration run --config-file custom.diesel.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel-derive-enum"
-version = "2.0.1"
+version = "2.1.0"
 description = "Derive diesel boilerplate for using enums in databases"
 authors = ["Alex Whitney <adwhit@fastmail.com>"]
 repository = "http://github.com/adwhit/diesel-derive-enum"
@@ -12,7 +12,7 @@ edition = "2021"
 
 [dependencies]
 quote = "1"
-syn = "1"
+syn = "2"
 heck = "0.4.0"
 proc-macro2 = "1"
 

--- a/README.md
+++ b/README.md
@@ -29,13 +29,16 @@ we wish to use with Diesel must implement various traits.
 Tedious to do by hand, easy to do with a `derive` macro - enter `diesel-derive-enum`.
 
 The latest release, `2.1.0`, is tested against `diesel 2.1.0` and `rustc 1.65`.
-For earlier versions of `diesel`, check out the 1.X releases of this crate.
+For earlier versions of `diesel`, check out the `2.0.1` and  `1.*` releases of this crate.
 
-## Upgrading from 2.0.0-rc.0
+## Upgrading from `2.0.0` -> `2.1.0`
 
-There is a single breaking change. If you are using `postgres` and `diesel-cli`, you _must_
-now add an `ExistingTypePath` annotation to your enum (see below). This annotation is renamed
-from the (previously optional) `DieselTypePath`.
+Due to changes in upstream `diesel_cli`, you may need to modify your existing `diesel.toml` file.
+As of version `2.1.0`, it **must** contain the following line:
+```
+custom_type_derives = ["diesel::query_builder::QueryId"]
+```
+So if it doesn't - add it!
 
 ## Setup with Diesel CLI
 
@@ -48,7 +51,7 @@ or if not using Diesel CLI, see the next section.
 Cargo.toml:
 ```toml
 [dependencies]
-diesel-derive-enum = { version = "2.0.1", features = ["postgres"] }
+diesel-derive-enum = { version = "2.1.0", features = ["postgres"] }
 ```
 
 Suppose our project has the following `diesel.toml`:
@@ -119,7 +122,7 @@ your schema, the setup is a little different.
 Cargo.toml:
 ```toml
 [dependencies]
-diesel-derive-enum = { version = "2.0.1", features = ["postgres"] }
+diesel-derive-enum = { version = "2.1.0", features = ["postgres"] }
 ```
 
 SQL:
@@ -157,7 +160,7 @@ table! {
 Cargo.toml:
 ```toml
 [dependencies]
-diesel-derive-enum = { version = "2.0.1", features = ["mysql"] }
+diesel-derive-enum = { version = "2.1.0", features = ["mysql"] }
 ```
 
 SQL:
@@ -194,7 +197,7 @@ table! {
 Cargo.toml:
 ```toml
 [dependencies]
-diesel-derive-enum = { version = "2.0.1", features = ["sqlite"] }
+diesel-derive-enum = { version = "2.1.0", features = ["sqlite"] }
 ```
 
 SQL:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Unfortunately, it won't work out of the box, because any type which
 we wish to use with Diesel must implement various traits.
 Tedious to do by hand, easy to do with a `derive` macro - enter `diesel-derive-enum`.
 
-The latest release, `2.0.1`, is tested against `diesel 2.0.2` and `rustc 1.57`.
+The latest release, `2.1.0`, is tested against `diesel 2.1.0` and `rustc 1.65`.
 For earlier versions of `diesel`, check out the 1.X releases of this crate.
 
 ## Upgrading from 2.0.0-rc.0

--- a/README.md
+++ b/README.md
@@ -31,11 +31,13 @@ Tedious to do by hand, easy to do with a `derive` macro - enter `diesel-derive-e
 The latest release, `2.1.0`, is tested against `diesel 2.1.0` and `rustc 1.65` (we try to keep in lock-step with `diesel`).
 For earlier versions of `diesel`, check out the `2.0.1` and  `1.*` releases of this crate.
 
-## Upgrading from `2.0.0` -> `2.1.0`
+## Upgrading from `2.0.x` -> `2.1.0`
 
-Due to changes in upstream `diesel_cli`, you may need to modify your existing `diesel.toml` file.
-As of version `2.1.0`, it **must** contain the following line:
+Using `diesel-cli`? Due to an upstream change, you may need to modify your existing `diesel.toml` file.
+As of version `2.1.0`, it **must** contain the following lines:
 ```
+[print-schema]
+# ... other config ...
 custom_type_derives = ["diesel::query_builder::QueryId"]
 ```
 So if it doesn't - add it!

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Unfortunately, it won't work out of the box, because any type which
 we wish to use with Diesel must implement various traits.
 Tedious to do by hand, easy to do with a `derive` macro - enter `diesel-derive-enum`.
 
-The latest release, `2.1.0`, is tested against `diesel 2.1.0` and `rustc 1.65`.
+The latest release, `2.1.0`, is tested against `diesel 2.1.0` and `rustc 1.65` (we try to keep in lock-step with `diesel`).
 For earlier versions of `diesel`, check out the `2.0.1` and  `1.*` releases of this crate.
 
 ## Upgrading from `2.0.0` -> `2.1.0`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,7 +304,7 @@ fn generate_new_diesel_mapping(
     // Note - we only generate a new mapping for mysql and sqlite, postgres
     // should already have one
     quote! {
-        #[derive(SqlType, Clone)]
+        #[derive(Clone, SqlType, diesel::query_builder::QueryId)]
         #[diesel(mysql_type(name = "Enum"))]
         #[diesel(sqlite_type(name = "Text"))]
         #[diesel(postgres_type(name = #pg_internal_type))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,7 +236,7 @@ fn generate_derive_enum_impls(
             deserialize::{self, FromSql},
             expression::AsExpression,
             internal::derives::as_expression::Bound,
-            query_builder::{bind_collector::RawBytesBindCollector, QueryId},
+            query_builder::{bind_collector::RawBytesBindCollector},
             row::Row,
             serialize::{self, IsNull, Output, ToSql},
             sql_types::*,
@@ -317,16 +317,6 @@ fn generate_common_impls(
     enum_ty: &Ident,
 ) -> proc_macro2::TokenStream {
     quote! {
-
-        // NOTE: at some point this impl will no longer be necessary
-        // for diesel-cli schemas
-        // See https://github.com/adwhit/diesel-derive-enum/issues/10
-        // and https://github.com/adwhit/diesel-derive-enum/pull/79
-        impl QueryId for #diesel_mapping {
-            type QueryId = #diesel_mapping;
-            const HAS_STATIC_QUERY_ID: bool = true;
-        }
-
         impl AsExpression<#diesel_mapping> for #enum_ty {
             type Expression = Bound<#diesel_mapping, Self>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,10 +95,14 @@ pub fn derive(input: TokenStream) -> TokenStream {
 
 fn val_from_attrs(attrs: &[Attribute], attrname: &str) -> Option<String> {
     for attr in attrs {
-        if attr.path.is_ident(attrname) {
-            match attr.parse_meta().ok()? {
+        if attr.path().is_ident(attrname) {
+            match &attr.meta {
                 Meta::NameValue(MetaNameValue {
-                    lit: Lit::Str(lit_str),
+                    value:
+                        Expr::Lit(ExprLit {
+                            lit: Lit::Str(lit_str),
+                            ..
+                        }),
                     ..
                 }) => return Some(lit_str.value()),
                 _ => panic!(

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "6776fc96284a0bb647b615056fc496d1fe1644a7ab01829818a6d91cae888b84"
 
 [[package]]
 name = "byteorder"
@@ -16,9 +16,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "diesel"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68c186a7418a2aac330bb76cde82f16c36b03a66fb91db32d20214311f9f6545"
+checksum = "f7a532c1f99a0f596f6960a60d1e119e91582b24b39e2d83a190e61262c3ef0c"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -28,79 +28,81 @@ dependencies = [
  "mysqlclient-sys",
  "percent-encoding",
  "pq-sys",
+ "time",
  "url",
 ]
 
 [[package]]
 name = "diesel-derive-enum"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "diesel_derives"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143b758c91dbc3fe1fdcb0dba5bd13276c6a66422f2ef5795b58488248a310aa"
+checksum = "74398b79d81e52e130d991afeed9c86034bb1b7735f46d2f5bf7deb261d80303"
 dependencies = [
- "proc-macro-error",
+ "diesel_table_macro_syntax",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
+]
+
+[[package]]
+name = "diesel_table_macro_syntax"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
+dependencies = [
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
- "matches",
  "percent-encoding",
 ]
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "idna"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
 dependencies = [
- "matches",
  "unicode-bidi",
  "unicode-normalization",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.2"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.25.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f835d03d717946d28b1d1ed632eb6f0e24a299388ee623d0c23118d3e8a7fa"
+checksum = "afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326"
 dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "matches"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "mysqlclient-sys"
@@ -114,76 +116,69 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.24"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "pq-sys"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac25eee5a0582f45a67e837e350d784e7003bd29a5f460796772061ca49ffda"
+checksum = "31c0052426df997c0cbd30789eb44ca097e3541717a7b8fa36b1c464ee7edebd"
 dependencies = [
  "vcpkg",
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.15"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "syn"
-version = "1.0.86"
+name = "serde"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -195,50 +190,76 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.5.1"
+name = "time"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
+checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
+dependencies = [
+ "itoa",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+
+[[package]]
+name = "time-macros"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
+dependencies = [
+ "time-core",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
 dependencies = [
  "tinyvec_macros",
 ]
 
 [[package]]
 name = "tinyvec_macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.7"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.19"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
 name = "url"
-version = "2.2.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
 dependencies = [
  "form_urlencoded",
  "idna",
- "matches",
  "percent-encoding",
 ]
 
@@ -247,9 +268,3 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -34,12 +34,12 @@ dependencies = [
 
 [[package]]
 name = "diesel-derive-enum"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -51,7 +51,7 @@ dependencies = [
  "diesel_table_macro_syntax",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn",
 ]
 
 [[package]]
@@ -60,7 +60,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
 dependencies = [
- "syn 2.0.18",
+ "syn",
 ]
 
 [[package]]
@@ -158,17 +158,6 @@ name = "serde"
 version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Alex Whitney <adwhit@fastmail.com>"]
 edition = "2021"
 
 [dependencies]
-diesel = "2.0.2"
+diesel = "2.1"
 diesel-derive-enum = { path = "./.." }
 
 [features]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Alex Whitney <adwhit@fastmail.com>"]
 edition = "2021"
 
 [dependencies]
-diesel = "2.1"
+diesel = "2.1.0"
 diesel-derive-enum = { path = "./.." }
 
 [features]

--- a/tests_with_diesel_cli/Cargo.lock
+++ b/tests_with_diesel_cli/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "6776fc96284a0bb647b615056fc496d1fe1644a7ab01829818a6d91cae888b84"
 
 [[package]]
 name = "byteorder"
@@ -16,9 +16,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "diesel"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68c186a7418a2aac330bb76cde82f16c36b03a66fb91db32d20214311f9f6545"
+checksum = "f7a532c1f99a0f596f6960a60d1e119e91582b24b39e2d83a190e61262c3ef0c"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -29,94 +29,90 @@ dependencies = [
 
 [[package]]
 name = "diesel-derive-enum"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "diesel_derives"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143b758c91dbc3fe1fdcb0dba5bd13276c6a66422f2ef5795b58488248a310aa"
+checksum = "74398b79d81e52e130d991afeed9c86034bb1b7735f46d2f5bf7deb261d80303"
 dependencies = [
- "proc-macro-error",
+ "diesel_table_macro_syntax",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
+]
+
+[[package]]
+name = "diesel_table_macro_syntax"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
+dependencies = [
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "pq-sys"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b845d6d8ec554f972a2c5298aad68953fd64e7441e846075450b44656a016d1"
+checksum = "31c0052426df997c0cbd30789eb44ca097e3541717a7b8fa36b1c464ee7edebd"
 dependencies = [
  "vcpkg",
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -133,18 +129,12 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"

--- a/tests_with_diesel_cli/Cargo.lock
+++ b/tests_with_diesel_cli/Cargo.lock
@@ -29,12 +29,12 @@ dependencies = [
 
 [[package]]
 name = "diesel-derive-enum"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -46,7 +46,7 @@ dependencies = [
  "diesel_table_macro_syntax",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn",
 ]
 
 [[package]]
@@ -55,7 +55,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
 dependencies = [
- "syn 2.0.18",
+ "syn",
 ]
 
 [[package]]
@@ -95,17 +95,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
 ]
 
 [[package]]

--- a/tests_with_diesel_cli/Cargo.toml
+++ b/tests_with_diesel_cli/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Alex Whitney <adwhit@fastmail.com>"]
 edition = "2021"
 
 [dependencies]
-diesel = { version = "2.1", features = ["postgres"] }
+diesel = { version = "2.1.0", features = ["postgres"] }
 diesel-derive-enum = { path = "./..", features = ["postgres"]}
 
 [features]

--- a/tests_with_diesel_cli/Cargo.toml
+++ b/tests_with_diesel_cli/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Alex Whitney <adwhit@fastmail.com>"]
 edition = "2021"
 
 [dependencies]
-diesel = { version = "2.0.2", features = ["postgres"] }
+diesel = { version = "2.1", features = ["postgres"] }
 diesel-derive-enum = { path = "./..", features = ["postgres"]}
 
 [features]

--- a/tests_with_diesel_cli/README.md
+++ b/tests_with_diesel_cli/README.md
@@ -1,0 +1,15 @@
+The purpose of these tests are to make sure the this crate integrates nicely with `diesel_cli`. First we run with default configuration (created by `diesel setup`), then with a custom config `custom.diesel.toml` which instructs `diesel_cli` not to generate the mapping types.
+
+To run these tests locally:
+
+* Make sure you have `libpq` installed
+  - You may have to mess around with your paths etc, see [stackoverflow](https://stackoverflow.com/questions/44654216/correct-way-to-install-psql-without-full-postgres-on-macos)
+* Also install `docker`/`docker-compose` and start daemon
+* Install the latest `diesel_cl`
+  - `cargo install diesel_cli -f --features postgres --no-default-features`
+
+Then:
+
+```bash
+./run.sh
+```

--- a/tests_with_diesel_cli/custom.diesel.toml
+++ b/tests_with_diesel_cli/custom.diesel.toml
@@ -1,6 +1,10 @@
 [print_schema]
 file = "src/custom_schema.rs"
+
+# We stop diesel from generating the enum mapping type
+# Instead we will do it through DbEnum
 generate_missing_sql_type_definitions = false
+
 import_types = ["diesel::sql_types::*", "crate::with_custom_schema::export::MyEnum"]
 
 [migrations_directory]

--- a/tests_with_diesel_cli/diesel.toml
+++ b/tests_with_diesel_cli/diesel.toml
@@ -1,2 +1,0 @@
-[print_schema]
-file = "src/schema.rs"

--- a/tests_with_diesel_cli/migrations/00000000000000_diesel_initial_setup/down.sql
+++ b/tests_with_diesel_cli/migrations/00000000000000_diesel_initial_setup/down.sql
@@ -1,0 +1,6 @@
+-- This file was automatically created by Diesel to setup helper functions
+-- and other internal bookkeeping. This file is safe to edit, any future
+-- changes will be added to existing projects as new migrations.
+
+DROP FUNCTION IF EXISTS diesel_manage_updated_at(_tbl regclass);
+DROP FUNCTION IF EXISTS diesel_set_updated_at();

--- a/tests_with_diesel_cli/migrations/00000000000000_diesel_initial_setup/up.sql
+++ b/tests_with_diesel_cli/migrations/00000000000000_diesel_initial_setup/up.sql
@@ -1,0 +1,36 @@
+-- This file was automatically created by Diesel to setup helper functions
+-- and other internal bookkeeping. This file is safe to edit, any future
+-- changes will be added to existing projects as new migrations.
+
+
+
+
+-- Sets up a trigger for the given table to automatically set a column called
+-- `updated_at` whenever the row is modified (unless `updated_at` was included
+-- in the modified columns)
+--
+-- # Example
+--
+-- ```sql
+-- CREATE TABLE users (id SERIAL PRIMARY KEY, updated_at TIMESTAMP NOT NULL DEFAULT NOW());
+--
+-- SELECT diesel_manage_updated_at('users');
+-- ```
+CREATE OR REPLACE FUNCTION diesel_manage_updated_at(_tbl regclass) RETURNS VOID AS $$
+BEGIN
+    EXECUTE format('CREATE TRIGGER set_updated_at BEFORE UPDATE ON %s
+                    FOR EACH ROW EXECUTE PROCEDURE diesel_set_updated_at()', _tbl);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION diesel_set_updated_at() RETURNS trigger AS $$
+BEGIN
+    IF (
+        NEW IS DISTINCT FROM OLD AND
+        NEW.updated_at IS NOT DISTINCT FROM OLD.updated_at
+    ) THEN
+        NEW.updated_at := current_timestamp;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/tests_with_diesel_cli/run.sh
+++ b/tests_with_diesel_cli/run.sh
@@ -11,10 +11,12 @@ docker-compose down
 docker-compose up -d
 sleep 2
 
+rm -f src/schema.rs diesel.toml
+diesel setup
 diesel migration run
 cargo test
 diesel migration revert
-rm src/schema.rs
+rm src/schema.rs diesel.toml
 
 # create a custom schema
 diesel migration run --config-file custom.diesel.toml

--- a/tests_with_diesel_cli/src/lib.rs
+++ b/tests_with_diesel_cli/src/lib.rs
@@ -18,3 +18,37 @@ pub fn get_connection() -> Conn {
         Conn::establish(&database_url).expect(&format!("Failed to connect to {}", database_url));
     conn
 }
+
+#[cfg(test)]
+mod tests {
+
+    #[cfg(not(feature = "custom"))]
+    use crate::schema::simple;
+    #[cfg(not(feature = "custom"))]
+    use crate::with_default_schema::*;
+
+    #[cfg(feature = "custom")]
+    use crate::custom_schema::simple;
+    #[cfg(feature = "custom")]
+    use crate::with_custom_schema::*;
+
+    use diesel::prelude::*;
+
+    #[test]
+    fn round_trip() {
+        let mut conn = crate::get_connection();
+        let this = Simple {
+            id: 1,
+            some_value: MyEnum::Foo,
+        };
+        let that = insert(&mut conn, &this).unwrap();
+        assert_eq!(this, that);
+
+        // make a query that requires QueryId trait to exist
+        let _: Vec<Simple> = simple::table
+            .filter(simple::some_value.eq(MyEnum::Foo))
+            .limit(1)
+            .load(&mut conn)
+            .unwrap();
+    }
+}

--- a/tests_with_diesel_cli/src/with_custom_schema.rs
+++ b/tests_with_diesel_cli/src/with_custom_schema.rs
@@ -25,22 +25,6 @@ pub fn insert(conn: &mut Conn, value: &Simple) -> Result<Simple, Error> {
         .get_result(conn)
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn round_trip() {
-        let mut conn = crate::get_connection();
-        let this = Simple {
-            id: 2,
-            some_value: MyEnum::BazQuxx,
-        };
-        let that = insert(&mut conn, &this).unwrap();
-        assert_eq!(this, that);
-    }
-}
-
 pub(crate) mod export {
     pub use super::MyEnumMapping as MyEnum;
 }

--- a/tests_with_diesel_cli/src/with_custom_schema.rs
+++ b/tests_with_diesel_cli/src/with_custom_schema.rs
@@ -5,6 +5,7 @@ use diesel::result::Error;
 use crate::custom_schema::simple;
 
 #[derive(diesel_derive_enum::DbEnum, Debug, Copy, Clone, PartialEq, Eq)]
+// NOTE: no ExistingTypePath, so we generate the mapping type ourselves
 pub enum MyEnum {
     Foo,
     Bar,

--- a/tests_with_diesel_cli/src/with_default_schema.rs
+++ b/tests_with_diesel_cli/src/with_default_schema.rs
@@ -24,26 +24,3 @@ pub fn insert(conn: &mut Conn, value: &Simple) -> Result<Simple, Error> {
         .values(value)
         .get_result(conn)
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn round_trip() {
-        let mut conn = crate::get_connection();
-        let this = Simple {
-            id: 1,
-            some_value: MyEnum::Foo,
-        };
-        let that = insert(&mut conn, &this).unwrap();
-        assert_eq!(this, that);
-
-        // make a query that requires QueryId trait to exist
-        let _: Vec<Simple> = simple::table
-            .filter(simple::some_value.eq(MyEnum::Foo))
-            .limit(1)
-            .load(&mut conn)
-            .unwrap();
-    }
-}


### PR DESCRIPTION
* rework so that `QueryId` is **only** derived if we create the custom mapping ourselves. Otherwise, rely upon `print-schema` to derive it for us
* Update tests to reflect this change

closes #91